### PR TITLE
Add minimap slash command

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,7 @@
 KeystoneCompanionDB = {
   settings = {
-    DevMode = false
+    DevMode = false,
+    MinimapButton = true
   }
 }
 

--- a/main.lua
+++ b/main.lua
@@ -134,7 +134,7 @@ function SlashCmdList.KEYSTONECOMPANION(msg, editBox)
     if(args[2] == 'on' or args[2] == 'enable') then
       KeystoneCompanionDB.settings.DevMode = true;
       print('Developer mode ' .. colorise('38ee45', 'enabled'));
-    elseif(args[2] == 'off' or args[2] == 'disables') then
+    elseif(args[2] == 'off' or args[2] == 'disable') then
       KeystoneCompanionDB.settings.DevMode = false;
       print('Developer mode ' .. colorise('00ffff', 'disabled'));
     else

--- a/main.lua
+++ b/main.lua
@@ -28,6 +28,11 @@ local function InitDataBrokerIcon()
   if(not LibDBIcon:GetMinimapButton('Keystone Companion')) then
     LibDBIcon:Register('Keystone Companion', dataBrokerObj, KeystoneCompanionDB.libDBIcon);
   end
+  if(KeystoneCompanionDB.settings.MinimapButton) then
+    LibDBIcon:Show('Keystone Companion')
+  else
+    LibDBIcon:Hide('Keystone Companion')
+  end
 end
 
 KeystoneCompanion.EventFrame = CreateFrame('Frame', 'KeystoneCompanionEventFrame')
@@ -139,6 +144,18 @@ function SlashCmdList.KEYSTONECOMPANION(msg, editBox)
       print('Developer mode ' .. colorise('00ffff', 'disabled'));
     else
       print('/kc dev [enable|on|disable|off]')
+    end
+  elseif(args[1] == 'minimap') then
+    if(args[2] == 'on' or args[2] == 'enable') then
+      KeystoneCompanionDB.settings.MinimapButton = true;
+      print('Minimap button ' .. colorise('38ee45', 'enabled'));
+      LibDBIcon:Show('Keystone Companion')
+    elseif(args[2] == 'off' or args[2] == 'disable') then
+      KeystoneCompanionDB.settings.MinimapButton = false;
+      print('Minimap button ' .. colorise('00ffff', 'disabled'));
+      LibDBIcon:Hide('Keystone Companion')
+    else
+      print('/kc minimap [enable|on|disable|off]')
     end
   end
 end


### PR DESCRIPTION
Add a slash command to toggle the minimap button from being shown

Usage: /kc minimap [enable|on|disable|off]

The LibDataBroker button will continue to be shown in LDB displays, as this only hides the minimap button itself. The setting will persist between reloads.